### PR TITLE
Fixed Issue #592

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1023,6 +1023,15 @@ ul.socials {
     margin: 0;
   }
 }
+
+/* responsive larger than 1600px screen */
+@media (min-width: 1600px) {
+  /* Heading */
+  .heading {
+    margin-top: 2%;
+  }
+}
+
 /* Responsive CSS for the heading*/
 @media (max-width: 760px) {
   .heading {


### PR DESCRIPTION
# Title and Issue number 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : **Theme Toggle Button Disappears in Large Monitor Screen(24inch Monitors)**

Issue No. :  #592
Close : #592 

Code Stack :  The part of code I added

```code
/* responsive larger than 1600px screen */
@media (min-width: 1600px) {
  /* Heading */
  .heading {
    margin-top: 2%;
  }
}
```

# How it Looks before
![Screenshot 2024-01-02 061209](https://github.com/apu52/METAVERSE/assets/61287791/99b220ce-f52c-4e32-811a-379fb99a4e54)
![Screenshot 2024-01-02 061227](https://github.com/apu52/METAVERSE/assets/61287791/846eacff-36b2-4eb2-ac7c-0ca7670f8071)

# How it Looks Now

![image](https://github.com/apu52/METAVERSE/assets/61287791/68f086b6-6c1f-46ec-bcac-40dde8420709)

![image](https://github.com/apu52/METAVERSE/assets/61287791/c9ebf263-ba9c-4421-a122-da2bbdd95341)



# Video (mandatory)
<!--Please try to attach the working video of your new deployed project here -->
<!-- It is not applicable for the templates of adding feature or fixing bugs -->

# Checklist:

- [x] I have mentioned the issue number in my Pull Request.
- [x] I have commented my code, particularly in hard-to-understand areas
<!-- [X] - put a cross/X inside [] to check the box -->






