### PR TITLE
fixed the about page footer and the home page link

### DIFF
--- a/about.html
+++ b/about.html
@@ -59,12 +59,10 @@
     <div class="container">
       
       <div class="radio-wrapper">
+        
         <div class="btn">
-        <a href="index.html">
-        </a>
-          <span aria-hidden="">HOME</span>
-          <span aria-hidden="" class="btn__glitch">_</span>
-          <label class="number">r1</label>
+            <a href="index.html">HOME</a>
+            <label class="number">r1</label>
         </div>
       </div>
       
@@ -139,10 +137,9 @@
   <h1 class="closure"></h1>     
   </div>
 
+  </main>
   
-  <!--
-        FOOTER
-  -->
+  <!-- FOOTER -->
   <div class="main" id="footer">
     <div>
       <svg class="waves" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -189,8 +186,6 @@
   </div>
   </section>
   </div>
-
-  </main>
 
   <!-- SCROLL TO TOP BUTTON -->
   <div id="progress">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1004,10 +1004,8 @@ ul.socials {
   }
 }
 
-/* responsive larger than 1250px screen */
-@media (min-width: 1250px) {
-  /* MAIN */
-
+/* making the layout responsive on tablets*/
+@media only screen and (min-width:600px) {
   main {
     max-width: 2000px;
     margin-inline: auto;
@@ -1017,8 +1015,16 @@ ul.socials {
     align-items: stretch;
     gap: 25px;
   }
+
+  .main-content{
+    width: 85%;
+  }
+}
+
+/* responsive larger than 1250px screen */
+@media (min-width: 1250px) {
+  /* MAIN */
   .main-content {
-    min-width: 75%;
     width: 75%;
     margin: 0;
   }
@@ -1316,11 +1322,17 @@ ul.socials {
   background: #282c34;
   font-size: 2vmin;
   font-family: JetBrains Mono, monospace;
-  height: 70vh;
-  width: 70vw;
+  height: 80vh;
+  width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+@media only screen and (max-width:600px){
+  #part{
+    height:60vh;
+  }
 }
 
 .string {

--- a/contact.html
+++ b/contact.html
@@ -61,6 +61,7 @@
         
         <div class="btn">
             <a href="index.html">HOME</a>
+            <label class="number">r1</label>
         </div>
       </div>
       <div class="radio-wrapper">


### PR DESCRIPTION
# Title and Issue number 

Title : fixed the about page footer and the achievement section along with the home page link on the about page and contact page.

Issue No. :#632

Code Stack : html, css

Close #632


# Video (mandatory)

video showcasing the home page link working on about page and responsive change on mobile, tablet and desktop to the same page:  


https://github.com/apu52/METAVERSE/assets/32983571/d5102736-4710-4423-9986-ecaed7fe938f


# Checklist:

- [x] I have mentioned the issue number in my Pull Request.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have created a helpful and easy to understand `README.md`
- [x] I have gone through the  `contributing.md` file before contributing


**Additional context (Mandatory )**
this issue caused the footer not be rendered properly as you can see in the live version below:
![image](https://github.com/apu52/METAVERSE/assets/32983571/c1fc32da-baf0-46c4-827a-2b1ed6c0ac51)

the home page link on the about page does not work.
the "r1" label is missing from home page link on contact page.
![image](https://github.com/apu52/METAVERSE/assets/32983571/4a528344-8f09-4579-81b0-5ba8fa9e781c)


***Are you contributing under any Open-source programme?***
GSSOC24'




