### PR TITLE
fixed unclickable links of contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -137,7 +137,7 @@
             
         </div>        
       </h5> 
-      <p>
+      <p style="z-index: 10;">
         <a href="https://www.youtube.com/@arpanchowdhury53" aria-label="Follow me on Youtube" title="Youtube (External Link)"
               rel="noopener noreferrer" target="_blank"> Youtube  <i class="fa fa-youtube" aria-hidden="true"></i></a>
         <a href="https://twitter.com/ArpanCh40193288" aria-label="Follow me on Twitter" title="Twitter (External Link)"


### PR DESCRIPTION
# Title and Issue number 

Title : fixed unclickable links of contact page

Issue No. :  #643 

Closes #643 


# Video (mandatory)
the issue was that the wordcarousel's unordered lists were overriding the p in which the about us links are there
![image](https://github.com/apu52/METAVERSE/assets/136828553/124075a9-67dc-4b04-8abe-2c406332ebed)




i just added a zindex of 10 to the p tag so it appears on top of it
![image](https://github.com/apu52/METAVERSE/assets/136828553/85882691-7dc1-4063-b5b7-41f023aa920d)



now the links are clickable
![image](https://github.com/apu52/METAVERSE/assets/136828553/b0eeb4c1-2c63-4bc6-83dd-698947258bfc)



# Checklist:

- [x] I have mentioned the issue number in my Pull Request.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have created a helpful and easy to understand `README.md`
- [x] I have gone through the  `contributing.md` file before contributing




***Are you contributing under any Open-source programme?***
yes i am contributing under gssoc 24



