### PR TITLE
fixed the animated text on contact page for mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1059,7 +1059,7 @@ ul.socials {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding-top: 5lh;
+  margin-top:2rem;
 }
 
 .owner-info {
@@ -1255,30 +1255,23 @@ ul.socials {
 .animated-title {
   color: #27bcda;
   font-family: "Mina", sans-serif;
-  height: 90vmin;
-  left: 50%;
-  position: absolute;
-  top: 50%;
-  transform: translate(-50%, -50%);
   width: 90vmin;
+  margin-inline: auto;
 }
 .animated-title > div {
-  height: 50%;
   overflow: hidden;
-  position: absolute;
   width: 100%;
 }
 .animated-title > div div {
   font-size: 10vmin;
   padding: 2vmin 0;
-  position: absolute;
 }
 .animated-title > div div span {
   display: block;
 }
 .animated-title > div.text-top {
   border-bottom: 1vmin solid #fcf8f8;
-  padding-top: 20lh;
+  margin-top: 2rem;
 }
 .animated-title > div.text-top div {
   animation: showTopText 0.5s;

--- a/contact.html
+++ b/contact.html
@@ -107,7 +107,7 @@
   <br>
   <br>
  <!-- Two-sided box with inline CSS -->
- <div class="animated-title" style="margin-top:200px">
+ <div class="animated-title" >
   <div class="text-top">
     <div>
       <span>Repo Owner</span>
@@ -116,7 +116,7 @@
   </div>
   
 </div>
- <div class="owner-info-container" style="margin-top:340px">
+ <div class="owner-info-container" >
     <div class="owner-info" style="text-align: center;">
       <img src="arpan.jpeg" alt="" class="image">
     </div>


### PR DESCRIPTION
# Title and Issue number 

Title : Repo owner text overlaps on mobile

Issue No. : #695 

Close #695 
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->


# Video (mandatory)

https://github.com/apu52/METAVERSE/assets/32983571/dfaf67e6-4ec6-4f92-8073-9892c9fa5558



# Checklist:

- [x] I have mentioned the issue number in my Pull Request.
- [ ] I have commented my code, particularly in hard-to-understand areas (no comments needed)
- [x] I have created a helpful and easy to understand `README.md`
- [x] I have gone through the  `contributing.md` file before contributing


**Additional context (Mandatory )**
With this fix the owner text does not overlap with the name.

***Are you contributing under any Open-source programme?***
Gssoc 24'




