### PR TITLE
Fixed Social Media links in the About Page!

### DIFF
--- a/about.html
+++ b/about.html
@@ -23,6 +23,7 @@
   <link rel="stylesheet" href="style.css">
   <link rel="shortcut icon" href="./images/metaverse.png" type="image/x-icon">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+  <script src="https://kit.fontawesome.com/1a1ffb78ee.js" crossorigin="anonymous"></script>
   
   <!--
     - custom css link
@@ -175,11 +176,11 @@
           </div>
 
             <ul class="socials">
-            <li><a href="" aria-label="Follow me on Github" title="Github (External Link)"
+            <li><a href="https://github.com/apu52/METAVERSE" aria-label="Follow me on Github" title="Github (External Link)"
                 rel="noopener noreferrer" target="_blank"><i class="fa fa-github" aria-hidden="true"></i></a></li>
-            <li><a href="" aria-label="Follow me on Twitter" title="Twitter (External Link)"
-                rel="noopener noreferrer" target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i></a></li>
-            <li><a href="" aria-label="Follow me on Linkedin"
+            <li><a href="https://twitter.com/ArpanCh40193288" aria-label="Follow me on Twitter" title="Twitter (External Link)"
+                rel="noopener noreferrer" target="_blank"><i class="fa-brands fa-x-twitter" aria-hidden="true"></i></a></li>
+            <li><a href="https://www.linkedin.com/in/arpan-chowdhury-775294251" aria-label="Follow me on Linkedin"
                 title="Linkedin (External Link)" rel="noopener noreferrer" target="_blank"><i
                   class="fa fa-linkedin-square" aria-hidden="true"></i></a></li>
           </ul> 

--- a/contact.html
+++ b/contact.html
@@ -190,9 +190,9 @@
             <ul class="socials">
             <li><a href="https://github.com/apu52/METAVERSE" aria-label="Follow me on Github" title="Github (External Link)"
                 rel="noopener noreferrer" target="_blank"><i class="fa fa-github" aria-hidden="true"></i></a></li>
-            <li><a href="" aria-label="Follow me on Twitter" title="Twitter (External Link)"
+            <li><a href="https://twitter.com/ArpanCh40193288" aria-label="Follow me on Twitter" title="Twitter (External Link)"
                 rel="noopener noreferrer" target="_blank"><i class="fa-brands fa-x-twitter" aria-hidden="true"></i></a></li>
-            <li><a href="" aria-label="Follow me on Linkedin"
+            <li><a href="https://www.linkedin.com/in/arpan-chowdhury-775294251" aria-label="Follow me on Linkedin"
                 title="Linkedin (External Link)" rel="noopener noreferrer" target="_blank"><i
                   class="fa fa-linkedin-square" aria-hidden="true"></i></a></li>
           </ul> 

--- a/contact.html
+++ b/contact.html
@@ -23,6 +23,7 @@
   <link rel="stylesheet" href="style.css">
   <link rel="shortcut icon" href="./images/metaverse.png" type="image/x-icon">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+  <script src="https://kit.fontawesome.com/1a1ffb78ee.js" crossorigin="anonymous"></script>
   
   <!--
     - custom css link
@@ -139,7 +140,7 @@
         <a href="https://www.youtube.com/@arpanchowdhury53" aria-label="Follow me on Youtube" title="Youtube (External Link)"
               rel="noopener noreferrer" target="_blank"> Youtube  <i class="fa fa-youtube" aria-hidden="true"></i></a>
         <a href="https://twitter.com/ArpanCh40193288" aria-label="Follow me on Twitter" title="Twitter (External Link)"
-              rel="noopener noreferrer" target="_blank"> Twitter  <i class="fa fa-twitter" aria-hidden="true"></i></a>
+              rel="noopener noreferrer" target="_blank"> Twitter  <i class="fa-brands fa-x-twitter" aria-hidden="true"></i></a>
         <a href= "https://www.linkedin.com/in/arpan-chowdhury-775294251" aria-label="Follow me on Linkedin"
               title="Linkedin (External Link)" rel="noopener noreferrer" target="_blank">LinkedIn  <i
                 class="fa fa-linkedin-square" aria-hidden="true"></i></a>
@@ -190,7 +191,7 @@
             <li><a href="https://github.com/apu52/METAVERSE" aria-label="Follow me on Github" title="Github (External Link)"
                 rel="noopener noreferrer" target="_blank"><i class="fa fa-github" aria-hidden="true"></i></a></li>
             <li><a href="" aria-label="Follow me on Twitter" title="Twitter (External Link)"
-                rel="noopener noreferrer" target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i></a></li>
+                rel="noopener noreferrer" target="_blank"><i class="fa-brands fa-x-twitter" aria-hidden="true"></i></a></li>
             <li><a href="" aria-label="Follow me on Linkedin"
                 title="Linkedin (External Link)" rel="noopener noreferrer" target="_blank"><i
                   class="fa fa-linkedin-square" aria-hidden="true"></i></a></li>


### PR DESCRIPTION
# Title and Issue number 
I have attached your social media handles so that when a user clicks on any of the social media icon, he/she can now redirect to that particular page. Moreover I have also replaced the old Twitter logo with the new one.

Issue No. : #690 

Close : #690 


# Attachments:
_(Before)_

![Screenshot (24)](https://github.com/apu52/METAVERSE/assets/169380578/ac3454b2-b02c-4187-be41-7f55006170ff)

_(After)_
![Screenshot (29)](https://github.com/apu52/METAVERSE/assets/169380578/aa480a2b-9aa1-4721-aa95-bb1fc4f7abf0)

![Screenshot (28)](https://github.com/apu52/METAVERSE/assets/169380578/3c9c86d3-6dcb-444f-90ba-338683e27871)



# Checklist:

- [x] I have mentioned the issue number in my Pull Request.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have gone through the  `contributing.md` file before contributing


<!-- [X] - put a cross/X inside [] to check the box -->
**Additional context (Mandatory )**

***Are you contributing under any Open-source programme?***
GSSoC'24






