### PR TITLE
FIX: Contact Us Form - Name Field Validation

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -617,7 +617,9 @@
             <form id="contact-form" class="contact-form">
               <div class="form-group">
                 <label for="name">Name</label>
-                <input type="text" id="name" name="name" required class="funky-input">
+                <input type="text" id="name" name="name" required class="funky-input" pattern="[a-zA-Z ]+"
+                    oninvalid="this.setCustomValidity('Numbers and Symbols are not allowed')"
+                    oninput="this.setCustomValidity('')">
               </div>
               <div class="form-group">
                 <label for="email">Email</label>


### PR DESCRIPTION
# Title of the Pull Request
Validate the Contact Us section's Name Field to Accept Only Letters.

# Description
This PR addresses Issue #1274 by validating the Contact Us form's Name field to only accept alphabetical letters.

Issue No. :#1274


Close #1274


# Type of PR

- [x] Bug fix


#Screenshot

Before
![image](https://github.com/user-attachments/assets/6d439241-4f31-48da-8fc6-033a0eb2b1ca)

After
![image](https://github.com/user-attachments/assets/1492a0f7-30ae-4db6-97cc-abb7e11b1209)



# Checklist:

- [x] I have mentioned the issue number in my Pull Request.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have gone through the  `contributing.md` file before contributing
- [x] I have Starred the Repository.




**Additional context **
The "Name" field in the Contact Us section should only accept alphabetical letters (a-z, A-Z), effectively preventing invalid or spam submissions.

***Are you contributing under any Open-source programme?***
<!--Mention it here-->
- [x] I'm a GSSOC'24 extended contributor
- [x] I'm a Winter of Blockchain(WOB'24) contributor
- [x] I'm a Hactoberfest'24 contributor  





