### PR TITLE
Refactor and restore common styles in style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -128,9 +128,7 @@
     background: linear-gradient(to right, rgba(128, 128, 128, 0.5), rgba(64, 64, 64, 0.5));
     position: fixed;
     top: 0;
-    left: 20%;
-    width: 85%;
-    align-items: stretch;
+    width: 100%;
     height: auto; /* Adjust height for mobile */
     z-index: 100;
     padding: 1rem;
@@ -142,7 +140,6 @@
   }
 
   .radio-wrapper{
-    width: 100%;
     margin: 5px 0;
   }
 
@@ -176,4 +173,5 @@
     transform: rotate(-45deg) translate(5px, -5px);
   }
 }
+
 


### PR DESCRIPTION
# Title and Issue number
Title: navbar menu layout breaks after toggle on smaller screens
Issue No.: #1416

Tech Stack: CSS, HTML, JavaScript

Close #1416

# Type of PR
- Bug fix

#  Screenshots

<img width="426" height="721" alt="Screenshot 2026-01-04 114455" src="https://github.com/user-attachments/assets/7984d5ad-881a-432d-b20c-3885cb266dfd" />
<img width="731" height="820" alt="Screenshot 2026-01-04 114505" src="https://github.com/user-attachments/assets/13d2bebd-f336-4187-b2a1-e7ee4ca707f8" />

# Description
Adjusted the `.container` and `.radio-wrapper` alignment to ensure the navbar menu and radio elements display correctly across mobile, tablet, and desktop screen sizes. Fixed misalignment and overlapping issues after toggling the navbar on smaller screens.

This PR fixes the responsive navbar layout without affecting other sections. Media queries were adjusted and flex alignment corrected for consistent behavior across all devices.
