### PR TITLE
Fix navbar styling inconsistency - Issue #1456

### DIFF
--- a/style.css
+++ b/style.css
@@ -123,8 +123,7 @@
 }
 
 @media (max-width: 768px) {
-  .container {
-    flex-direction: column;
+  .main-content .container {
     background: linear-gradient(to right, rgba(128, 128, 128, 0.5), rgba(64, 64, 64, 0.5));
     position: fixed;
     top: 0;
@@ -176,4 +175,5 @@
     transform: rotate(-45deg) translate(5px, -5px);
   }
 }
+
 


### PR DESCRIPTION
## Description
Modified `.container` selector to `.main-content .container` in `@media (max-width: 768px)` query to prevent navbar styling conflicts.

This ensures the responsive styles only apply to content containers, not the navigation bar, resolving the frosted glass effect and layout issues.

## Issue No.
#1456

## Tech Stack
CSS, HTML

Close #1456

## Type of PR
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Add WEB3 project
- [ ] Other (specify): ____________

## Screenshots/Video
Refer to Issue #1456 for before/after screenshots and live site testing.

## Checklist:
- [x] I have mentioned the issue number in my Pull Request.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have gone through the `contributing.md` file before contributing
- [x] I have Starred the Repository